### PR TITLE
[FE #42] Axios Interseptor

### DIFF
--- a/FE/vue/src/api/common/interceptors.js
+++ b/FE/vue/src/api/common/interceptors.js
@@ -1,0 +1,23 @@
+// import store from '@/store/index';
+
+export function setInterceptors(instance) {
+  instance.interceptors.request.use(
+    function (config) {
+      // config.headers.Authorization = store.state.token;
+      return config;
+    },
+    function (error) {
+      return Promise.reject(error);
+    },
+  );
+
+  instance.interceptors.response.use(
+    function (response) {
+      return response;
+    },
+    function (error) {
+      return Promise.reject(error);
+    },
+  );
+  return instance;
+}

--- a/FE/vue/src/api/index.js
+++ b/FE/vue/src/api/index.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+import { setInterceptors } from './common/interceptors';
+
+function createInstance() {
+  return axios.create({
+    baseURL: process.env.VUE_APP_BASE_URL,
+  });
+}
+
+function createInstanceWithAuth(url) {
+  const instance = axios.create({
+    baseURL: `${process.env.VUE_APP_BASE_URL}${url}`,
+  });
+  return setInterceptors(instance);
+}
+
+export const instance = createInstance();
+export const authoriztion = createInstanceWithAuth('authorization/');

--- a/FE/vue/src/api/issue.js
+++ b/FE/vue/src/api/issue.js
@@ -1,0 +1,7 @@
+import { instance, authoriztion } from './index';
+
+function initMainRender() {
+  return instance.get('');
+}
+
+export { initMainRender };


### PR DESCRIPTION
### 백엔드 통신을 위한 axios 설정을 해둔다

- token값으로 인증된 사용자만 요청을 보낼수있도록 설정해둔다
- axios conig에 token값을 설정해둔다
- 요청을 보내기전에 interseptor에서 axios를 생성하면서 header에 설정된 토큰값을 사용한다
